### PR TITLE
:pencil2: Correct typo

### DIFF
--- a/utils/utils_ade20k.py
+++ b/utils/utils_ade20k.py
@@ -101,7 +101,7 @@ def plot_polygon(img_name, info, show_obj=True, show_parts=False):
         all_poly += info['objects']['polygon']
     if show_parts:
         all_objects += info['parts']['class']
-        all_poly += info['objects']['polygon']
+        all_poly += info['parts']['polygon']
 
     img = cv2.imread(img_name)
     thickness = 5


### PR DESCRIPTION
typo in plot_polygon function, with show_parts=True.
Parts Polygons displayed are those of Objects